### PR TITLE
Feature/json schema validator

### DIFF
--- a/TensorIO/.gitignore
+++ b/TensorIO/.gitignore
@@ -1,12 +1,11 @@
 *.iml
 .gradle
 /local.properties
-/.idea/caches
-/.idea/libraries
-/.idea/modules.xml
-/.idea/workspace.xml
-/.idea/navEditor.xml
-/.idea/assetWizardSettings.xml
+
+
+# Android Studio
+.idea
+
 .DS_Store
 /build
 /captures

--- a/TensorIO/tensorio/build.gradle
+++ b/TensorIO/tensorio/build.gradle
@@ -27,6 +27,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    packagingOptions {
+        pickFirst 'META-INF/ASL-2.0.txt'
+        pickFirst 'draftv4/schema'
+        pickFirst 'draftv3/schema'
+        pickFirst 'META-INF/LICENSE'
+        pickFirst 'META-INF/LGPL-3.0.txt'
+    }
 }
 
 repositories {
@@ -44,4 +52,8 @@ dependencies {
 
     // Tensorflow dependency
     implementation 'org.tensorflow:tensorflow-lite:0.0.0-gpu-experimental'
+
+    // JSON Schema validator library dependencies
+    implementation 'com.github.java-json-tools:json-schema-validator:2.2.10'
+    implementation 'io.apisense:rhino-android:1.0'
 }

--- a/TensorIO/tensorio/src/androidTest/java/ai/doc/tensorio/IntegrationTests.java
+++ b/TensorIO/tensorio/src/androidTest/java/ai/doc/tensorio/IntegrationTests.java
@@ -7,14 +7,19 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.support.test.InstrumentationRegistry;
 
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+
 import org.junit.Test;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 import ai.doc.tensorio.TIOModel.TIOModelBundle;
 import ai.doc.tensorio.TIOModel.TIOModelBundleException;
+import ai.doc.tensorio.TIOModel.TIOModelBundleValidator;
 import ai.doc.tensorio.TIOModel.TIOModelException;
 import ai.doc.tensorio.TIOTensorflowLiteModel.TIOTFLiteModel;
 
@@ -437,4 +442,25 @@ public class IntegrationTests {
         }
     }
 
+    @Test
+    public void testTIOModelBundleValidator() {
+        Context context = InstrumentationRegistry.getTargetContext();
+        try {
+            String[] assets = context.getAssets().list("");
+            for(String s: assets){
+                if (s.endsWith(".tfbundle")){
+                    InputStream inputStream = context.getAssets().open(s + "/model.json");
+                    int size = inputStream.available();
+                    byte[] buffer = new byte[size];
+                    inputStream.read(buffer);
+                    inputStream.close();
+                    String modelJSON = new String(buffer, "UTF-8");
+                    assertEquals(true, TIOModelBundleValidator.ValidateTFLite(context, modelJSON));
+                }
+            }
+        } catch(IOException  | ProcessingException ex) {
+            ex.printStackTrace();
+            fail();
+        }
+    }
 }

--- a/TensorIO/tensorio/src/main/assets/TFLite/model-schema.json
+++ b/TensorIO/tensorio/src/main/assets/TFLite/model-schema.json
@@ -1,0 +1,309 @@
+{
+  "$schema":  "http://json-schema.org/draft-07/schema#",
+  "$id":      "https://github.com/doc-ai/tensorio/schemas/v0.7.0/tflite/schema.json",
+
+  "definitions": {
+
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "file",
+        "quantized"
+      ],
+      "properties": {
+        "file":       { "type":   "string"  },
+        "quantized":  { "type":   "boolean" },
+        "type":       { "type":   "string"  },
+        "backend":    { "type":   "string",
+          "const":  "tflite"  },
+        "class":      { "type":   "string"  },
+        "modes":      {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["predict"]
+          }
+        }
+      }
+    },
+
+    "options": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "device_position":  { "type": "string" },
+        "output_format":    { "type": "string" }
+      }
+    },
+
+    "input.array.quantize": {
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "standard": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "scale":    { "type": "number" },
+            "bias":     { "type": "number" }
+          }
+        }
+      ]
+    },
+
+    "input.array": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "shape"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["array"]
+        },
+        "dtype": {
+          "type": "string",
+          "enum": ["uint8, float32"]
+        },
+        "shape": {
+          "type": "array",
+          "items": { "type": "integer" }
+        },
+        "quantize": {
+          "$ref": "#/definitions/input.array.quantize"
+        }
+      }
+    },
+
+    "input.image.normalize": {
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "standard": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "scale":    { "type": "number" },
+            "bias": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "r":    { "type": "number" },
+                "g":    { "type": "number" },
+                "b":    { "type": "number" }
+              }
+            }
+          }
+        }
+      ]
+    },
+
+    "input.image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "shape",
+        "format"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["image"]
+        },
+        "name": {
+          "type": "string"
+        },
+        "shape": {
+          "type": "array",
+          "items": { "type": "integer" }
+        },
+        "format": {
+          "type": "string",
+          "enum": ["RGB", "BGR"]
+        },
+        "normalize": {
+          "$ref": "#/definitions/input.image.normalize"
+        }
+      }
+    },
+
+    "output.array.dequantize": {
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "standard": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "scale":    { "type": "number" },
+            "bias":     { "type": "number" }
+          }
+        }
+      ]
+    },
+
+    "output.array": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "shape"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["array"]
+        },
+        "dtype": {
+          "type": "string",
+          "enum": ["uint8, float32"]
+        },
+        "shape": {
+          "type": "array",
+          "items": { "type": "integer" }
+        },
+        "labels": {
+          "type": "string"
+        },
+        "dequantize": {
+          "$ref": "#/definitions/output.array.dequantize"
+        }
+      }
+    },
+
+    "output.image.denormalize": {
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "standard": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "scale":    { "type": "number" },
+            "bias": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "r":    { "type": "number" },
+                "g":    { "type": "number" },
+                "b":    { "type": "number" }
+              }
+            }
+          }
+        }
+      ]
+    },
+
+    "output.image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "shape",
+        "format"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["image"]
+        },
+        "name": {
+          "type": "string"
+        },
+        "shape": {
+          "type": "array",
+          "items": { "type": "integer" }
+        },
+        "format": {
+          "type": "string",
+          "enum": ["RGB", "BGR"]
+        },
+        "denormalize": {
+          "$ref": "#/definitions/output.image.denormalize"
+        }
+      }
+    }
+
+  },
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "name",
+    "details",
+    "id",
+    "version",
+    "author",
+    "license",
+    "model",
+    "inputs",
+    "outputs"
+  ],
+  "properties": {
+    "name":         { "type": "string" },
+    "details":      { "type": "string" },
+    "id":           { "type": "string" },
+    "version":      { "type": "string" },
+    "author":       { "type": "string" },
+    "license":      { "type": "string" },
+    "placeholder":  { "type": "boolean" },
+    "model":        { "$ref": "#/definitions/model" },
+    "inputs": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "$ref": "#/definitions/input.array" },
+          { "$ref": "#/definitions/input.image" }
+        ]
+      }
+    },
+    "outputs": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "$ref": "#/definitions/output.array" },
+          { "$ref": "#/definitions/output.image" }
+        ]
+      }
+    },
+    "options": { "$ref": "#/definitions/options" }
+  }
+}

--- a/TensorIO/tensorio/src/main/java/ai/doc/tensorio/TIOModel/TIOModelBundleValidator.java
+++ b/TensorIO/tensorio/src/main/java/ai/doc/tensorio/TIOModel/TIOModelBundleValidator.java
@@ -1,7 +1,6 @@
 package ai.doc.tensorio.TIOModel;
 
 import android.content.Context;
-import android.util.Log;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jackson.JsonLoader;

--- a/TensorIO/tensorio/src/main/java/ai/doc/tensorio/TIOModel/TIOModelBundleValidator.java
+++ b/TensorIO/tensorio/src/main/java/ai/doc/tensorio/TIOModel/TIOModelBundleValidator.java
@@ -1,0 +1,44 @@
+package ai.doc.tensorio.TIOModel;
+
+import android.content.Context;
+import android.util.Log;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.fge.jackson.JsonLoader;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
+import com.github.fge.jsonschema.main.JsonSchema;
+import com.github.fge.jsonschema.main.JsonSchemaFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public abstract class TIOModelBundleValidator {
+
+    /**
+     * Validates the string representation of the json with the TFLite json schema file in the assets folder at TFLite/mode-schema.json.
+     * The validation is done with json-schema-validator library using the JSON Schema Internet draft Version 4.
+     * More info about the schema draft can be found at https://tools.ietf.org/html/draft-zyp-json-schema-04.
+     *
+     * @param context Context object. The context is needed to get access to assets folder where the mode-schema.json file is stored.
+     * @param json The string representation of the json object to validate.
+     * @return if the provided json is validated against the schema.
+     * @throws IOException IOException is thrown if the TFLite/model-schema.json file is not found inside the assets folder.
+     * @throws ProcessingException ProcessingException is thrown if the JsonSchemaFactory cannot get the JsonSchema from the schemaNode.
+     */
+    public static boolean ValidateTFLite(Context context, String json) throws IOException, ProcessingException {
+        InputStream inputStream = context.getAssets().open("TFLite/model-schema.json");
+        int size = inputStream.available();
+        byte[] buffer = new byte[size];
+        inputStream.read(buffer);
+        inputStream.close();
+        String modelSchema = new String(buffer, "UTF-8");
+
+        JsonNode schemaNode = JsonLoader.fromString(modelSchema);
+        JsonNode data = JsonLoader.fromString(json);
+        JsonSchemaFactory factory = JsonSchemaFactory.byDefault();
+        JsonSchema schema = factory.getJsonSchema(schemaNode);
+        ProcessingReport report = schema.validate(data);
+        return report.isSuccess();
+    }
+}


### PR DESCRIPTION
Added the json schema validation code and the test in side the IntegrationTests. The library used for schema validation is https://github.com/java-json-tools/json-schema-validator version 2.2.10 and the validation is done with the Schema draft version 4.

The JSON schema for validation is inside the assets folder at TFLite/model-schema.json file. 
The models tfbundle files are stored in the assets folder as well.
The schema in the model-schema.json file is from the tensorio-ios repo.
Tested the validation successfully with valid and invalid model.json files.